### PR TITLE
set max-line-length for linters to 110

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands = {posargs}
 
 [flake8]
 # E123, E125 skipped as they are invalid PEP-8.
-
+max-line-length = 110
 show-source = True
 ignore = E123,E125
 builtins = _


### PR DESCRIPTION
Sets the linter max-line-length to 110.