### PR TITLE
added scale data comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Touchstone currently supports comparison of the following docs:
 |      Vegeta    |  Elasticsearch   |    Ripsaw     |
 |    Kubeburner  |  Elasticsearch   |    Ripsaw     |
 
+Touchstone also supports the comparison of following data from Elasticsearch -
+- Scale up/down
+
 ## Usage
 
 It is suggested to use a venv to install and run touchstone.

--- a/src/touchstone/benchmarks/scaledata.py
+++ b/src/touchstone/benchmarks/scaledata.py
@@ -1,0 +1,80 @@
+import logging
+
+
+from . import BenchmarkBaseClass
+
+
+_logger = logging.getLogger("touchstone")
+
+
+class Scaledata(BenchmarkBaseClass):
+
+    def _build_search(self):
+        _logger.debug("Building search array for Scale data")
+        return self._search_dict[self._source_type][self._harness_type]
+
+    def _build_search_metadata(self):
+        return self._search_dict[self._source_type]["metadata"]
+
+    def _build_compare_keys(self):
+        _logger.debug("Building compare map")
+        _temp_dict = {}
+        for index in self._search_map:
+            _temp_dict[index] = self._search_map[index]['compare']
+        return _temp_dict
+
+    def _build_compute(self):
+        _logger.debug("Building compute map")
+        _temp_dict = {}
+        for index in self._search_map:
+            _temp_dict[index] = self._search_map[index]['compute']
+        return _temp_dict
+
+    def __init__(self, source_type=None, harness_type=None):
+        _logger.debug("Initializing Scale data instance")
+        BenchmarkBaseClass.__init__(self, source_type=source_type,
+                                    harness_type=harness_type)
+        self._search_dict = {
+            'elasticsearch': {
+                'metadata': {
+
+                },
+                'ripsaw': {
+                    'openshift-cluster-timings': {
+                        'compare': ['uuid', 'cluster_name', 'action'],
+                        'compute': [{
+                            'filter': {},
+                            'buckets': ['platform.keyword', 'master_count', 'infra_count',
+                                        'init_worker_count', 'action.keyword', 'worker_count'],
+                            'aggregations': {
+                                'duration': ['avg'],
+                            },
+                            'collate': []
+                        }, ],
+                    },
+                },
+            },
+        }
+        self._search_map = self._build_search()
+        self._search_map_metadata = self._build_search_metadata()
+        self._compute_map = self._build_compute()
+        self._compare_map = self._build_compare_keys()
+        _logger.debug("Finished initializing Scale data instance")
+
+    def emit_compute_map(self):
+        _logger.debug("Emitting built compute map ")
+        _logger.info("Compute map is {} in the database \
+                     {}".format(self._compute_map, self._source_type))
+        return self._compute_map
+
+    def emit_compare_map(self):
+        _logger.debug("Emitting built compare map ")
+        _logger.info("compare map is {} in the database \
+                     {}".format(self._compare_map, self._source_type))
+        return self._compare_map
+
+    def emit_indices(self):
+        return self._search_map.keys()
+
+    def emit_metadata_search_map(self):
+        return self._search_map_metadata

--- a/src/touchstone/compare.py
+++ b/src/touchstone/compare.py
@@ -38,7 +38,7 @@ def parse_args(args):
         dest="benchmark",
         help="which type of benchmark to compare",
         type=str,
-        choices=['uperf', 'ycsb', 'pgbench', 'vegeta', 'mb', 'kubeburner'],
+        choices=['uperf', 'ycsb', 'pgbench', 'vegeta', 'mb', 'kubeburner', 'scaledata'],
         metavar="benchmark")
     parser.add_argument(
         dest="database",


### PR DESCRIPTION
This pr adds the comaprison for the scale data from the index "openshift-cluster-timings" [https://issues.redhat.com/browse/PERFSCALE-762]

Sample Input -
`touchstone_compare scaledata elasticsearch  ripsaw -url search-cloud-perf-lqrf3jjtaqo7727m7ynd2xyt4y.us-west-2.es.amazonaws.com:80 -u e7cfd83a-cf45-5729-b8ac-db1c00eac178 2b7e8b93-f42c-5cb9-ac5d-8690b8713491 -o csv -output-file demo.csv -v`

Output -
| platform | master_count | infra_count | init_worker_count | action     | worker_count | key           | uuid                                 | value |
|----------|--------------|-------------|-------------------|------------|--------------|---------------|--------------------------------------|-------|
| AWS      | 3            | 0           | 1                 | scale_down | 0            | avg(duration) | e7cfd83a-cf45-5729-b8ac-db1c00eac178 | 50.0  |
| AWS      | 3            | 0           | 1                 | scale_down | 0            | avg(duration) | 2b7e8b93-f42c-5cb9-ac5d-8690b8713491 | 54.0  |