### PR TITLE
Add scale_uperf example config file

### DIFF
--- a/examples/scale_uperf.json
+++ b/examples/scale_uperf.json
@@ -54,10 +54,15 @@
             }
           ],
           "buckets": [
+            "density",
+            "nodes_in_iter",
+            "client_node.keyword",
+            "client_ips.keyword",
             "protocol.keyword",
             "message_size",
             "read_message_size",
-            "num_threads"
+            "num_threads",
+            "pod_id"
           ],
           "aggregations": {
             "norm_ops": [

--- a/examples/scale_uperf.json
+++ b/examples/scale_uperf.json
@@ -35,7 +35,8 @@
             "protocol.keyword",
             "message_size",
             "read_message_size",
-            "num_threads"
+            "num_threads",
+            "pod_id"
           ],
           "aggregations": {
             "norm_byte": [

--- a/examples/scale_uperf.json
+++ b/examples/scale_uperf.json
@@ -1,0 +1,83 @@
+{
+  "elasticsearch": {
+    "metadata": {
+      "cpuinfo-metadata": {
+        "element": "pod_name",
+        "compare": [
+          "value.Model name",
+          "value.Architecture",
+          "value.CPU(s)"
+        ]
+      },
+      "meminfo-metadata": {
+        "element": "pod_name",
+        "compare": [
+          "value.MemTotal"
+        ]
+      }
+    },
+    "ripsaw": {
+      "ripsaw-uperf-results": [
+        {
+          "filter": {
+            "test_type.keyword": "stream"
+          },
+          "exclude": [
+            {
+              "norm_ops": 0
+            }
+          ],
+          "buckets": [
+            "density",
+            "nodes_in_iter",
+            "client_node.keyword",
+            "client_ips.keyword",
+            "protocol.keyword",
+            "message_size",
+            "read_message_size",
+            "num_threads"
+          ],
+          "aggregations": {
+            "norm_byte": [
+              "avg"
+            ]
+          }
+        },
+        {
+          "filter": {
+            "test_type.keyword": "rr"
+          },
+          "exclude": [
+            {
+              "norm_ops": 0
+            }
+          ],
+          "buckets": [
+            "protocol.keyword",
+            "message_size",
+            "read_message_size",
+            "num_threads"
+          ],
+          "aggregations": {
+            "norm_ops": [
+              "max",
+              "avg"
+            ],
+            "norm_ltcy": [
+              {
+                "percentiles": {
+                  "percents": [
+                    90,
+                    99
+                  ]
+                }
+              },
+              "avg"
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+

--- a/src/touchstone/benchmarks/uperf.py
+++ b/src/touchstone/benchmarks/uperf.py
@@ -52,8 +52,6 @@ class Uperf(BenchmarkBaseClass):
                                 "protocol.keyword",
                                 "message_size",
                                 "num_threads",
-                                "density",
-                                "nodes_in_iter",
                             ],
                             "aggregations": {
                                 "norm_byte": [
@@ -70,8 +68,6 @@ class Uperf(BenchmarkBaseClass):
                                 "protocol.keyword",
                                 "message_size",
                                 "num_threads",
-                                "density",
-                                "nodes_in_iter",
                             ],
                             "aggregations": {
                                 "norm_ops": ["max", "avg"],


### PR DESCRIPTION
the scale_uperf.json file has the variables that have been added from the scale efforts. This file allows the user to query the new variables, additional aggregations can be added for min/max as desired. 