### PR TITLE
Correct license from MIT to Apache 2.0

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -11,4 +11,3 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,21 +1,14 @@
-The MIT License (MIT)
+Copyright 2019 aakarshg
 
-Copyright (c) 2019 aakarshg
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+    http://www.apache.org/licenses/LICENSE-2.0
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ name = touchstone
 description = To compare benchmark results in elasticsearch
 author = aakarshg
 author-email = aakarsh.g2012@gmail.com
-license = mit
+license = Apache License 2.0
 long-description = file: README.md
 long-description-content-type = text/markdown; charset=UTF-8
 classifiers =

--- a/src/touchstone/compare.py
+++ b/src/touchstone/compare.py
@@ -15,7 +15,7 @@ from .utils.lib import mergedicts, flatten_and_discard
 
 __author__ = "red-hat-perfscale"
 __copyright__ = "red-hat-perfscale"
-__license__ = "mit"
+__license__ = "Apache License 2.0"
 
 logger = logging.getLogger("touchstone")
 


### PR DESCRIPTION
### Description

Correct the license declared in various files. Was set to MIT when it should be set to Apache 2.0