### PR TITLE
Set dependency versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ Touchstone is a framework written in python that provides you an apples to apple
 It is suggested to use a venv to install and run touchstone.
 
 ```shell
-$ python -m venv /path/to/new/virtual/environment
-source /path/to/new/virtual/environment/bin/activate
+python -m venv /virtual/environment
+source /virtual/environment/bin/activate
 git clone https://github.com/cloud-bulldozer/touchstone
+cd touchstone
 python setup.py develop
 touchstone_compare -h
 usage: touchstone_compare [-h] [--version] [--database {elasticsearch}] [--identifier-key IDENTIFIER] -u UUID [UUID ...] [-o {json,yaml,csv}] --config CONFIG [--output-file OUTPUT_FILE] [--tolerancy-rules TOLERANCY_RULES] -url CONN_URL

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,10 +6,10 @@
 name = touchstone
 description = To compare benchmark results in elasticsearch
 author = aakarshg
-author-email = aakarsh.g2012@gmail.com
+author_email = aakarsh.g2012@gmail.com
 license = Apache License 2.0
-long-description = file: README.md
-long-description-content-type = text/markdown; charset=UTF-8
+long_description = file: README.md
+long_description_content_type = text/markdown; charset=UTF-8
 classifiers =
     Development Status :: 4 - Beta
     Programming Language :: Python
@@ -21,10 +21,9 @@ include_package_data = True
 package_dir =
     =src
 # Add here dependencies of your project (semicolon/line-separated), e.g.
-install_requires = numpy; elasticsearch >= 6.7; elasticsearch_dsl >=6.7; tabulate; pyyaml
+install_requires = elasticsearch==7.10.0; elasticsearch_dsl==7.3.0; tabulate; pyyaml
 # tests_require = pytest; pytest-cov
-# Require a specific Python version, e.g. Python 2.7 or >= 3.4
-# python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
+python_requires=>=3.6,
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

Latest elasticsearch client version throws an error like:
```
elasticsearch.exceptions.NotElasticsearchError: The client noticed that the server is not Elasticsearch and we do not support this unknown product
```

Cleaning up numpy dependency as well.