### PR TITLE
Add --alias flag

### DIFF
--- a/src/touchstone/databases/elasticsearch.py
+++ b/src/touchstone/databases/elasticsearch.py
@@ -23,9 +23,11 @@ class Elasticsearch(DatabaseBaseClass):
         self._aggs_list = []
         logger.debug("Finished Initializing Elasticsearch object")
 
-    def gen_result_dict(self, reponse, buckets, aggs, uuid):
+    def gen_result_dict(self, response, buckets, aggs, uuid, alias):
+        if alias:
+            uuid = alias
         output_dict = {}
-        input_dict = reponse.aggs.__dict__
+        input_dict = response.aggs.__dict__
         # Remove .keyword from bucket names
         buckets = [e.split(".keyword")[0] for e in buckets]
 
@@ -55,7 +57,7 @@ class Elasticsearch(DatabaseBaseClass):
         build_dict(input_dict["_d_"], output_dict)
         return output_dict
 
-    def emit_compute_dict(self, uuid, compute_map, index, identifier):
+    def emit_compute_dict(self, uuid, compute_map, index, identifier, alias):
         """
         Returns the normalized data from the ES query
         """
@@ -117,7 +119,7 @@ fields are required in {compute_map}"
 
         if len(response.hits.hits) == 0:
             return {}
-        _output_dict = self.gen_result_dict(response, buckets, self._aggs_list, uuid)
+        _output_dict = self.gen_result_dict(response, buckets, self._aggs_list, uuid, alias)
         if filters:
             output_dict = _output_dict
             filter_list = []


### PR DESCRIPTION
### Description

New --alias flag that allows to replace the UUIDs by a series of aliases. This will ease reading and improve csv document generation.

Demo of the above:
```shell
touchstone_compare -url $ES_SERVER -u f744d60d-b492-46a7-903
5-d12755b6cd09 9df8255d-2038-42ed-869d-f748f671da07 --config config/mb.json --alias foo bar
+-----------+--------+----------------------+-----------+--------------------------+------+-----------+                                                                                                                                       
| test_type | routes | conn_per_targetroute | keepalive |           key            | uuid |   value   |
+-----------+--------+----------------------+-----------+--------------------------+------+-----------+                                                                                                                                       
|   http    |  500   |          1           |     0     | avg(requests_per_second) | foo  | 181814.5  |
|   http    |  500   |          1           |     0     | avg(requests_per_second) | bar  | 190073.0  |                                                                                                                                       
|   http    |  500   |          1           |     0     |   avg(latency_95pctl)    | foo  |  3855.0   |
|   http    |  500   |          1           |     0     |   avg(latency_95pctl)    | bar  |  3592.5   |                                                                                                                                       
|   http    |  500   |          1           |     1     | avg(requests_per_second) | foo  |  10024.0  |
|   http    |  500   |          1           |     1     | avg(requests_per_second) | bar  |  12328.0  |                                                                                                                                       
|   http    |  500   |          1           |     1     |   avg(latency_95pctl)    | foo  | 227326.5  |
|   http    |  500   |          1           |     1     |   avg(latency_95pctl)    | bar  |  82384.0  |                                                                                                                                       
|   http    |  500   |          1           |    50     | avg(requests_per_second) | foo  | 162219.0  |
|   http    |  500   |          1           |    50     | avg(requests_per_second) | bar  | 166809.0  |
|   http    |  500   |          1           |    50     |   avg(latency_95pctl)    | foo  |  4987.5   |
|   http    |  500   |          1           |    50     |   avg(latency_95pctl)    | bar  |  4932.5   |
|   http    |  500   |          20          |     0     | avg(requests_per_second) | foo  | 101695.0  |
|   http    |  500   |          20          |     0     | avg(requests_per_second) | bar  |  58743.5  |
|   http    |  500   |          20          |     0     |   avg(latency_95pctl)    | foo  | 163860.0  |
|   http    |  500   |          20          |     0     |   avg(latency_95pctl)    | bar  | 391660.5  |
|   http    |  500   |          20          |     1     | avg(requests_per_second) | foo  |  37887.0  |
|   http    |  500   |          20          |     1     | avg(requests_per_second) | bar  |  11437.5  |
```

### Fixes

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>