### PR TITLE
Update uperf config

### DIFF
--- a/config/uperf.json
+++ b/config/uperf.json
@@ -36,7 +36,8 @@
         "buckets": [
           "protocol.keyword",
           "message_size",
-          "num_threads"
+          "num_threads",
+          "num_pairs.keyword"
         ],
         "aggregations": {
           "norm_byte": [
@@ -55,7 +56,8 @@
         "buckets": [
           "protocol.keyword",
           "message_size",
-          "num_threads"
+          "num_threads",
+          "num_pairs.keyword"
         ],
         "aggregations": {
           "norm_ops": [


### PR DESCRIPTION
### Description
Previously each uperf pair had it's own UUID and touchstone would display results only for that pair, but now that all pairs(1,2,4) of a uperf run have the same UUID, this PR will help differentiate different pair aggregations for the same UUID in a single output.  
