### PR TITLE
Wildcard support

### DIFF
--- a/src/touchstone/databases/elasticsearch.py
+++ b/src/touchstone/databases/elasticsearch.py
@@ -83,7 +83,7 @@ fields are required in {compute_map}"
 
         # Apply filters
         for key, value in filters.items():
-            s = s.filter("term", **{key: value})
+            s = s.filter("wildcard", **{key: value})
 
         # Apply excludes
         for key, value in compute_map.get("exclude", {}).items():


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

Using the wildcard rather than term query provides more flexibility to filters.
i.e.
```json
{
  "elasticsearch": {
    "ripsaw-kube-burner": [
      {
        "filter": {
          "metricName.keyword": "containerCPU",
                  "labels.namespace.keyword": "openshift-ovn-kubernetes",
                  "labels.pod.keyword": "ovnkube-master*"
        },
                "buckets": [
                  "labels.container.keyword",
                  "labels.pod.keyword"
                ],
        "aggregations": {
          "value": [
            "avg"
          ]
        }
      }
    ]
  }
}

```

Provides an output similar to:

```
+--------------+--------------------------+-----------------+------------------+----------------------+------------+--------------------------------+
|  metricName  |     labels.namespace     |   labels.pod    | labels.container |      labels.pod      |   metric   | 430e5139-node-density-20220408 |
+--------------+--------------------------+-----------------+------------------+----------------------+------------+--------------------------------+
| containerCPU | openshift-ovn-kubernetes | ovnkube-master* | kube-rbac-proxy  | ovnkube-master-g7s6t | avg(value) |      0.015133480890654027      |
| containerCPU | openshift-ovn-kubernetes | ovnkube-master* | kube-rbac-proxy  | ovnkube-master-gbqw2 | avg(value) |      0.017597397246087592      |
| containerCPU | openshift-ovn-kubernetes | ovnkube-master* | kube-rbac-proxy  | ovnkube-master-rx24h | avg(value) |      0.015434125089086592      |
| containerCPU | openshift-ovn-kubernetes | ovnkube-master* |       nbdb       | ovnkube-master-g7s6t | avg(value) |       3.1132746984561286       |
| containerCPU | openshift-ovn-kubernetes | ovnkube-master* |       nbdb       | ovnkube-master-gbqw2 | avg(value) |       7.168618630617857        |
| containerCPU | openshift-ovn-kubernetes | ovnkube-master* |       nbdb       | ovnkube-master-rx24h | avg(value) |       3.2563021642466388       |
| containerCPU | openshift-ovn-kubernetes | ovnkube-master* |      northd      | ovnkube-master-g7s6t | avg(value) |       2.760873650511106        |
| containerCPU | openshift-ovn-kubernetes | ovnkube-master* |      northd      | ovnkube-master-gbqw2 | avg(value) |       63.611175601681076       |
| containerCPU | openshift-ovn-kubernetes | ovnkube-master* |      northd      | ovnkube-master-rx24h | avg(value) |       2.8194791128238044       |
| containerCPU | openshift-ovn-kubernetes | ovnkube-master* |  ovn-dbchecker   | ovnkube-master-g7s6t | avg(value) |      0.06453543150564656       |
| containerCPU | openshift-ovn-kubernetes | ovnkube-master* |  ovn-dbchecker   | ovnkube-master-gbqw2 | avg(value) |      0.06512801751280979       |
| containerCPU | openshift-ovn-kubernetes | ovnkube-master* |  ovn-dbchecker   | ovnkube-master-rx24h | avg(value) |      0.06913390214322135       |
| containerCPU | openshift-ovn-kubernetes | ovnkube-master* |  ovnkube-master  | ovnkube-master-g7s6t | avg(value) |       8.257742247233788        |
| containerCPU | openshift-ovn-kubernetes | ovnkube-master* |  ovnkube-master  | ovnkube-master-gbqw2 | avg(value) |       15.310267099489769       |
| containerCPU | openshift-ovn-kubernetes | ovnkube-master* |  ovnkube-master  | ovnkube-master-rx24h | avg(value) |       7.996908803159992        |
| containerCPU | openshift-ovn-kubernetes | ovnkube-master* |       sbdb       | ovnkube-master-g7s6t | avg(value) |       54.12079151471456        |
| containerCPU | openshift-ovn-kubernetes | ovnkube-master* |       sbdb       | ovnkube-master-gbqw2 | avg(value) |       6.563931258395314        |
| containerCPU | openshift-ovn-kubernetes | ovnkube-master* |       sbdb       | ovnkube-master-rx24h | avg(value) |        6.60373034949104        |
+--------------+--------------------------+-----------------+------------------+----------------------+------------+--------------------------------+

```

### Fixes
