### PR TITLE
Prevent printing table headers when no result is found

### DIFF
--- a/src/touchstone/decision_maker/__init__.py
+++ b/src/touchstone/decision_maker/__init__.py
@@ -71,9 +71,7 @@ class Compare:
                         recurse(data[k], json_path[1::], parent[k])
                 else:
                     if json_path[0] not in data:
-                        logger.error(
-                            f"Key {json_path[0]} key not found in current dict level: {list(data.keys())}"
-                        )
+                        self.passed = None
                         return
                     parent[json_path[0]] = {}
                     recurse(data[json_path[0]], json_path[1::], parent[json_path[0]])
@@ -105,6 +103,8 @@ def run(baseline_uuid, results_data, compute_header, output_file, args):
     for json_path in json_paths:
         c = Compare(baseline_uuid, results_data)
         passed = c.compare(json_path["json_path"], json_path["tolerancy"])
+        if passed is None:
+            continue
         if args.output == "yaml":
             print(yaml.dump({"tolerations": c.compare_dict}, indent=1), file=output_file)
         elif args.output == "json":


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

W/o this change

```
$ touchstone_compare --database elasticsearch -url blablabla.com  -u b9572257-5d70-46e4-83eb-fde76645be35 0097acd1-1f6e-4922-a6d6-4ece26456efd --config uperf-touchstone.json     --tolerancy-rules uperf-tolerancy-rules.yaml  
+-----------+----------+--------------+-------------+-----------+----------------+--------+-----------+--------------------------------------+--------------------------------------+
| test_type | protocol | message_size | num_threads | num_pairs |     metric     | result | deviation | b9572257-5d70-46e4-83eb-fde76645be35 | 0097acd1-1f6e-4922-a6d6-4ece26456efd |
+-----------+----------+--------------+-------------+-----------+----------------+--------+-----------+--------------------------------------+--------------------------------------+
|  stream   |   tcp    |     1024     |      1      |     4     | avg(norm_byte) |  Pass  |   0.51%   |            306978087.764             |            308555451.264             |
|  stream   |   tcp    |     1024     |      1      |     2     | avg(norm_byte) |  Pass  |   0.64%   |            577297157.611             |            580966480.067             |
|  stream   |   tcp    |     1024     |      1      |     1     | avg(norm_byte) |  Pass  |   1.78%   |            597251959.422             |            607854088.581             |
|  stream   |   tcp    |    16384     |      1      |     4     | avg(norm_byte) |  Pass  |   0.96%   |            307246967.357             |            310192082.358             |
|  stream   |   tcp    |    16384     |      1      |     2     | avg(norm_byte) |  Pass  |   0.10%   |            613194137.453             |            613799981.369             |
|  stream   |   tcp    |    16384     |      1      |     1     | avg(norm_byte) |  Pass  |   0.03%   |             616992312.8              |            617148142.767             |
|  stream   |   tcp    |      64      |      1      |     4     | avg(norm_byte) |  Pass  |  -11.40%  |             59954779.022             |             53119950.204             |
|  stream   |   tcp    |      64      |      1      |     2     | avg(norm_byte) |  Pass  |  -11.39%  |             62536234.667             |             55410636.792             |
|  stream   |   tcp    |      64      |      1      |     1     | avg(norm_byte) |  Pass  |  -13.90%  |             64615360.719             |             55634773.25              |
|  stream   |   udp    |     1024     |      1      |     4     | avg(norm_byte) |  Pass  |  -12.11%  |            167304680.501             |            147036988.885             |
|  stream   |   udp    |     1024     |      1      |     2     | avg(norm_byte) |  Pass  |  -12.82%  |            175936671.289             |            153377058.942             |
|  stream   |   udp    |     1024     |      1      |     1     | avg(norm_byte) |  Pass  |  -11.28%  |            179667308.089             |            159403303.822             |
|  stream   |   udp    |      64      |      1      |     4     | avg(norm_byte) |  Pass  |  -13.76%  |             10731334.596             |             9254678.756              |
|  stream   |   udp    |      64      |      1      |     2     | avg(norm_byte) |  Pass  |  -10.61%  |             10920726.756             |             9762460.444              |
|  stream   |   udp    |      64      |      1      |     1     | avg(norm_byte) |  Pass  |  -14.39%  |             11638055.822             |             9963099.022              |
|  stream   |   udp    |    16384     |      1      |     4     | avg(norm_byte) |  Pass  |  11.17%   |            1082092878.687            |            1202983927.443            |
|  stream   |   udp    |    16384     |      1      |     2     | avg(norm_byte) |  Pass  |  -7.47%   |            1151024649.983            |             1065084518.4             |
|  stream   |   udp    |    16384     |      1      |     1     | avg(norm_byte) |  Pass  |  -8.79%   |             1250964275.2             |            1140957595.888            |
+-----------+----------+--------------+-------------+-----------+----------------+--------+-----------+--------------------------------------+--------------------------------------+            
+-----------+----------+--------------+-------------+-----------+--------+--------+-----------+--------------------------------------+--------------------------------------+                    
| test_type | protocol | message_size | num_threads | num_pairs | metric | result | deviation | b9572257-5d70-46e4-83eb-fde76645be35 | 0097acd1-1f6e-4922-a6d6-4ece26456efd |                    
+-----------+----------+--------------+-------------+-----------+--------+--------+-----------+--------------------------------------+--------------------------------------+                    
+-----------+----------+--------------+-------------+-----------+--------+--------+-----------+--------------------------------------+--------------------------------------+                    
+-----------+----------+--------------+-------------+-----------+--------+--------+-----------+--------------------------------------+--------------------------------------+                    
| test_type | protocol | message_size | num_threads | num_pairs | metric | result | deviation | b9572257-5d70-46e4-83eb-fde76645be35 | 0097acd1-1f6e-4922-a6d6-4ece26456efd |                    
+-----------+----------+--------------+-------------+-----------+--------+--------+-----------+--------------------------------------+--------------------------------------+                    
+-----------+----------+--------------+-------------+-----------+--------+--------+-----------+--------------------------------------+--------------------------------------+                    
+-----------+----------+--------------+-------------+-----------+----------------------------+--------+-----------+--------------------------------------+--------------------------------------+
| test_type | protocol | message_size | num_threads | num_pairs |           metric           | result | deviation | b9572257-5d70-46e4-83eb-fde76645be35 | 0097acd1-1f6e-4922-a6d6-4ece26456efd |
+-----------+----------+--------------+-------------+-----------+----------------------------+--------+-----------+--------------------------------------+--------------------------------------+
|    rr     |   tcp    |     1024     |      1      |     4     | 99.0percentiles(norm_ltcy) |  Pass  |  -4.58%   |               389.063                |               371.237                |
|    rr     |   tcp    |     1024     |      1      |     2     | 99.0percentiles(norm_ltcy) |  Pass  |  -0.01%   |                371.15                |               371.131                |
|    rr     |   tcp    |     1024     |      1      |     1     | 99.0percentiles(norm_ltcy) |  Pass  |  -4.37%   |               384.491                |               367.699                |
|    rr     |   tcp    |    16384     |      1      |     4     | 99.0percentiles(norm_ltcy) |  Pass  |  -6.77%   |               443.519                |               413.484                |
|    rr     |   tcp    |    16384     |      1      |     2     | 99.0percentiles(norm_ltcy) |  Pass  |  -2.76%   |               424.702                |               412.996                |
|    rr     |   tcp    |    16384     |      1      |     1     | 99.0percentiles(norm_ltcy) |  Pass  |  -7.21%   |               441.227                |               409.429                |
|    rr     |   tcp    |      64      |      1      |     4     | 99.0percentiles(norm_ltcy) |  Pass  |  -2.70%   |               381.534                |               371.224                |
|    rr     |   tcp    |      64      |      1      |     2     | 99.0percentiles(norm_ltcy) |  Pass  |   1.64%   |               358.525                |               364.395                |
|    rr     |   tcp    |      64      |      1      |     1     | 99.0percentiles(norm_ltcy) |  Pass  |  -3.20%   |               378.894                |               366.756                |
|    rr     |   udp    |      64      |      1      |     4     | 99.0percentiles(norm_ltcy) |  Pass  |  -4.25%   |               381.596                |               365.364                |
|    rr     |   udp    |      64      |      1      |     2     | 99.0percentiles(norm_ltcy) |  Pass  |  -3.62%   |               377.809                |               364.137                |                                             
|    rr     |   udp    |      64      |      1      |     1     | 99.0percentiles(norm_ltcy) |  Pass  |  -5.09%   |               380.346                |               360.996                |
|    rr     |   udp    |     1024     |      1      |     4     | 99.0percentiles(norm_ltcy) |  Pass  |  -2.69%   |               380.138                |               369.928                |                   
|    rr     |   udp    |     1024     |      1      |     2     | 99.0percentiles(norm_ltcy) |  Pass  |  -3.72%   |               380.553                |               366.404                |
|    rr     |   udp    |     1024     |      1      |     1     | 99.0percentiles(norm_ltcy) |  Pass  |  -4.01%   |               383.394                |                368.02                |
|    rr     |   udp    |    16384     |      1      |     4     | 99.0percentiles(norm_ltcy) |  Pass  |  -4.78%   |               442.564                |               421.414                |
|    rr     |   udp    |    16384     |      1      |     2     | 99.0percentiles(norm_ltcy) |  Pass  |  -7.67%   |               449.452                |               414.998                |
|    rr     |   udp    |    16384     |      1      |     1     | 99.0percentiles(norm_ltcy) |  Pass  |  -1.48%   |                423.69                |               417.425                |
+-----------+----------+--------------+-------------+-----------+----------------------------+--------+-----------+--------------------------------------+--------------------------------------+
```

With this change:
```
+-----------+----------+--------------+-------------+-----------+----------------+--------+-----------+--------------------------------------+--------------------------------------+
| test_type | protocol | message_size | num_threads | num_pairs |     metric     | result | deviation | b9572257-5d70-46e4-83eb-fde76645be35 | 0097acd1-1f6e-4922-a6d6-4ece26456efd |
+-----------+----------+--------------+-------------+-----------+----------------+--------+-----------+--------------------------------------+--------------------------------------+
|  stream   |   tcp    |     1024     |      1      |     4     | avg(norm_byte) |  Pass  |   0.51%   |            306978087.764             |            308555451.264             |
|  stream   |   tcp    |     1024     |      1      |     2     | avg(norm_byte) |  Pass  |   0.64%   |            577297157.611             |            580966480.067             |
|  stream   |   tcp    |     1024     |      1      |     1     | avg(norm_byte) |  Pass  |   1.78%   |            597251959.422             |            607854088.581             |
|  stream   |   tcp    |    16384     |      1      |     4     | avg(norm_byte) |  Pass  |   0.96%   |            307246967.357             |            310192082.358             |
|  stream   |   tcp    |    16384     |      1      |     2     | avg(norm_byte) |  Pass  |   0.10%   |            613194137.453             |            613799981.369             |
|  stream   |   tcp    |    16384     |      1      |     1     | avg(norm_byte) |  Pass  |   0.03%   |             616992312.8              |            617148142.767             |
|  stream   |   tcp    |      64      |      1      |     4     | avg(norm_byte) |  Pass  |  -11.40%  |             59954779.022             |             53119950.204             |
|  stream   |   tcp    |      64      |      1      |     2     | avg(norm_byte) |  Pass  |  -11.39%  |             62536234.667             |             55410636.792             |
|  stream   |   tcp    |      64      |      1      |     1     | avg(norm_byte) |  Pass  |  -13.90%  |             64615360.719             |             55634773.25              |
|  stream   |   udp    |     1024     |      1      |     4     | avg(norm_byte) |  Pass  |  -12.11%  |            167304680.501             |            147036988.885             |
|  stream   |   udp    |     1024     |      1      |     2     | avg(norm_byte) |  Pass  |  -12.82%  |            175936671.289             |            153377058.942             |
|  stream   |   udp    |     1024     |      1      |     1     | avg(norm_byte) |  Pass  |  -11.28%  |            179667308.089             |            159403303.822             |
|  stream   |   udp    |      64      |      1      |     4     | avg(norm_byte) |  Pass  |  -13.76%  |             10731334.596             |             9254678.756              |
|  stream   |   udp    |      64      |      1      |     2     | avg(norm_byte) |  Pass  |  -10.61%  |             10920726.756             |             9762460.444              |
|  stream   |   udp    |      64      |      1      |     1     | avg(norm_byte) |  Pass  |  -14.39%  |             11638055.822             |             9963099.022              |
|  stream   |   udp    |    16384     |      1      |     4     | avg(norm_byte) |  Pass  |  11.17%   |            1082092878.687            |            1202983927.443            |
|  stream   |   udp    |    16384     |      1      |     2     | avg(norm_byte) |  Pass  |  -7.47%   |            1151024649.983            |             1065084518.4             |
|  stream   |   udp    |    16384     |      1      |     1     | avg(norm_byte) |  Pass  |  -8.79%   |             1250964275.2             |            1140957595.888            |
+-----------+----------+--------------+-------------+-----------+----------------+--------+-----------+--------------------------------------+--------------------------------------+
+-----------+----------+--------------+-------------+-----------+----------------------------+--------+-----------+--------------------------------------+--------------------------------------+
| test_type | protocol | message_size | num_threads | num_pairs |           metric           | result | deviation | b9572257-5d70-46e4-83eb-fde76645be35 | 0097acd1-1f6e-4922-a6d6-4ece26456efd |
+-----------+----------+--------------+-------------+-----------+----------------------------+--------+-----------+--------------------------------------+--------------------------------------+
|    rr     |   tcp    |     1024     |      1      |     4     | 99.0percentiles(norm_ltcy) |  Pass  |  -4.58%   |               389.063                |               371.237                |
|    rr     |   tcp    |     1024     |      1      |     2     | 99.0percentiles(norm_ltcy) |  Pass  |  -0.01%   |                371.15                |               371.131                |
|    rr     |   tcp    |     1024     |      1      |     1     | 99.0percentiles(norm_ltcy) |  Pass  |  -4.37%   |               384.491                |               367.699                |
|    rr     |   tcp    |    16384     |      1      |     4     | 99.0percentiles(norm_ltcy) |  Pass  |  -6.77%   |               443.519                |               413.484                |
|    rr     |   tcp    |    16384     |      1      |     2     | 99.0percentiles(norm_ltcy) |  Pass  |  -2.76%   |               424.702                |               412.996                |
|    rr     |   tcp    |    16384     |      1      |     1     | 99.0percentiles(norm_ltcy) |  Pass  |  -7.21%   |               441.227                |               409.429                |
|    rr     |   tcp    |      64      |      1      |     4     | 99.0percentiles(norm_ltcy) |  Pass  |  -2.70%   |               381.534                |               371.224                |
|    rr     |   tcp    |      64      |      1      |     2     | 99.0percentiles(norm_ltcy) |  Pass  |   1.64%   |               358.525                |               364.395                |
|    rr     |   tcp    |      64      |      1      |     1     | 99.0percentiles(norm_ltcy) |  Pass  |  -3.20%   |               378.894                |               366.756                |
|    rr     |   udp    |      64      |      1      |     4     | 99.0percentiles(norm_ltcy) |  Pass  |  -4.25%   |               381.596                |               365.364                |
|    rr     |   udp    |      64      |      1      |     2     | 99.0percentiles(norm_ltcy) |  Pass  |  -3.62%   |               377.809                |               364.137                |
|    rr     |   udp    |      64      |      1      |     1     | 99.0percentiles(norm_ltcy) |  Pass  |  -5.09%   |               380.346                |               360.996                |
|    rr     |   udp    |     1024     |      1      |     4     | 99.0percentiles(norm_ltcy) |  Pass  |  -2.69%   |               380.138                |               369.928                |
|    rr     |   udp    |     1024     |      1      |     2     | 99.0percentiles(norm_ltcy) |  Pass  |  -3.72%   |               380.553                |               366.404                |
|    rr     |   udp    |     1024     |      1      |     1     | 99.0percentiles(norm_ltcy) |  Pass  |  -4.01%   |               383.394                |                368.02                |
|    rr     |   udp    |    16384     |      1      |     4     | 99.0percentiles(norm_ltcy) |  Pass  |  -4.78%   |               442.564                |               421.414                |
|    rr     |   udp    |    16384     |      1      |     2     | 99.0percentiles(norm_ltcy) |  Pass  |  -7.67%   |               449.452                |               414.998                |
|    rr     |   udp    |    16384     |      1      |     1     | 99.0percentiles(norm_ltcy) |  Pass  |  -1.48%   |                423.69                |               417.425                |
+-----------+----------+--------------+-------------+-----------+----------------------------+--------+-----------+--------------------------------------+--------------------------------------+
```

