### PR TITLE
Search all ripsaw-kube-burner indices

### DIFF
--- a/config/kubeburner-control-plane.json
+++ b/config/kubeburner-control-plane.json
@@ -7,7 +7,7 @@
                 ]
             }
         },
-        "ripsaw-kube-burner": [
+        "ripsaw-kube-burner*": [
             {
                 "filter": {
                     "labels.namespace.keyword": "openshift-kube-apiserver",

--- a/config/kubeburner.json
+++ b/config/kubeburner.json
@@ -7,7 +7,7 @@
         ]
       }
     },
-    "ripsaw-kube-burner": [
+    "ripsaw-kube-burner*": [
       {
         "filter": {
           "metricName.keyword": "podLatencyQuantilesMeasurement"

--- a/src/touchstone/databases/elasticsearch.py
+++ b/src/touchstone/databases/elasticsearch.py
@@ -72,8 +72,7 @@ class Elasticsearch(DatabaseBaseClass):
         output_dict = {}
         if "aggregations" not in compute_map:
             logger.critical(
-                f"Incorrect JSON data: nested dictionaries aggregations \
-fields are required in {compute_map}"
+                f"Incorrect JSON data: nested dictionaries aggregations fields are required in {compute_map}"
             )
             return output_dict
         buckets = compute_map.get("buckets", [])


### PR DESCRIPTION
### Description

ripsaw-kube-burner exists as many indices, so the wildcard allows us to search across all of them.

### Fixes

An error received when data is known to be available: `touchstone - ERROR - Error: Issue capturing results from elasticsearch using config `