### PR TITLE
Adding config files and comparison specific jobNames

### DIFF
--- a/config/crio-jobName.json
+++ b/config/crio-jobName.json
@@ -1,0 +1,34 @@
+{
+  "elasticsearch": {
+    "ripsaw-kube-burner": [
+      {
+        "filter": {
+          "metricName.keyword": "crioCPU"
+        },
+        "buckets": [
+          "jobName.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            "max",
+            "avg"
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "crioMemory"
+        },
+        "buckets": [
+          "jobName.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            "max",
+            "avg"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/config/etcd-jobName.json
+++ b/config/etcd-jobName.json
@@ -1,0 +1,45 @@
+{
+  "elasticsearch": {
+    "ripsaw-kube-burner": [
+      {
+        "filter": {
+          "metricName.keyword": "99thEtcdDiskBackendCommitDurationSeconds"
+        },
+        "buckets": [
+          "jobName.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            "max"
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "99thEtcdDiskWalFsyncDurationSeconds"
+        },
+        "buckets": [
+          "jobName.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            "max"
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "99thEtcdRoundTripTimeSeconds"
+        },
+        "buckets": [
+          "jobName.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            "max"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/config/kubelet-jobName.json
+++ b/config/kubelet-jobName.json
@@ -1,0 +1,32 @@
+{
+  "elasticsearch": {
+    "ripsaw-kube-burner": [
+      {
+        "filter": {
+          "metricName.keyword": "kubeletCPU"
+        },
+        "buckets": [
+          "jobName.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            "max"
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "kubeletMemory"
+        },
+        "buckets": [
+          "jobName.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            "max"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/config/nodeAggWorkers-jobName.json
+++ b/config/nodeAggWorkers-jobName.json
@@ -1,0 +1,34 @@
+{
+  "elasticsearch": {
+    "ripsaw-kube-burner": [
+      {
+        "filter": {
+          "metricName.keyword": "nodeCPU-AggregatedWorkers"
+        },
+        "buckets": [
+          "labels.mode.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            "avg",
+            "max"
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "nodeMemoryAvailable-AggregatedWorkers"
+        },
+        "buckets": [
+          "jobName.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            "avg",
+            "max"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/config/nodeMasters-jobName.json
+++ b/config/nodeMasters-jobName.json
@@ -1,0 +1,32 @@
+{
+  "elasticsearch": {
+    "ripsaw-kube-burner": [
+      {
+        "filter": {
+          "metricName.keyword": "nodeCPU-Masters"
+        },
+        "buckets": [
+          "labels.mode.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            "max"
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "nodeMemoryUtilization-Masters"
+        },
+        "buckets": [
+          "jobName.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            "max"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/config/nodeWorkers-jobName.json
+++ b/config/nodeWorkers-jobName.json
@@ -1,0 +1,34 @@
+{
+  "elasticsearch": {
+    "ripsaw-kube-burner": [
+      {
+        "filter": {
+          "metricName.keyword": "nodeCPU-Workers"
+        },
+        "buckets": [
+          "labels.mode.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            "max",
+            "avg"
+          ]
+        }
+      },
+      {
+        "filter": {
+          "metricName.keyword": "nodeMemoryUtilization-Workers"
+        },
+        "buckets": [
+          "jobName.keyword"
+        ],
+        "aggregations": {
+          "value": [
+            "max",
+            "avg"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/tolerancy-configs/crio-tolerancy.yaml
+++ b/tolerancy-configs/crio-tolerancy.yaml
@@ -1,0 +1,8 @@
+- json_path: ["metricName", "crioCPU","jobName","*", "max(value)"]
+  tolerancy: 20
+  # Maximum percentage of allowed failures
+  max_failures: 0
+- json_path: ["metricName", "crioMemory","jobName","*", "max(value)"]
+  tolerancy: 15
+  # Maximum percentage of allowed failures
+  max_failures: 0

--- a/tolerancy-configs/etcd-tolerancy.yaml
+++ b/tolerancy-configs/etcd-tolerancy.yaml
@@ -1,0 +1,12 @@
+- json_path: ["metricName", "99thEtcdDiskBackendCommitDurationSeconds", "jobName","*","max(value)"]
+  tolerancy: 40
+  # Maximum percentage of allowed failures
+  max_failures: 100
+- json_path: ["metricName", "99thEtcdDiskWalFsyncDurationSeconds", "jobName","*","max(value)"]
+  tolerancy: 40
+  # Maximum percentage of allowed failures
+  max_failures: 100
+- json_path: ["metricName", "99thEtcdRoundTripTimeSeconds", "jobName","*","max(value)"]
+  tolerancy: 40
+  # Maximum percentage of allowed failures
+  max_failures: 100

--- a/tolerancy-configs/kube-burner-cp-tolerancy.yaml
+++ b/tolerancy-configs/kube-burner-cp-tolerancy.yaml
@@ -1,0 +1,16 @@
+- json_path: ["metricName", "containerCPU-Masters", "labels.namespace", "openshift-kube-apiserver", "avg(value)"]
+  tolerancy: -15
+  # Maximum percentage of allowed failures
+  max_failures: 100
+- json_path: ["metricName", "containerMemory-Masters", "labels.namespace", "openshift-kube-apiserver", "avg(value)"]
+  tolerancy: -15
+  # Maximum percentage of allowed failures
+  max_failures: 100
+- json_path: ["metricName", "containerCPU-Masters", "labels.namespace", "openshift-etcd", "avg(value)"]
+  tolerancy: -15
+  # Maximum percentage of allowed failures
+  max_failures: 100
+- json_path: ["metricName", "containerMemory-Masters", "labels.namespace", "openshift-etcd", "avg(value)"]
+  tolerancy: -15
+  # Maximum percentage of allowed failures
+  max_failures: 100

--- a/tolerancy-configs/kubelet-tolerancy.yaml
+++ b/tolerancy-configs/kubelet-tolerancy.yaml
@@ -1,0 +1,8 @@
+- json_path: ["metricName", "kubeletCPU", "jobName", "*", "max(value)"]
+  tolerancy: -15
+  # Maximum percentage of allowed failures
+  max_failures: 100
+- json_path: ["metricName", "kubeletMemory", "jobName", "*", "max(value)"]
+  tolerancy: -15
+  # Maximum percentage of allowed failures
+  max_failures: 100

--- a/tolerancy-configs/master-tolerancy.yaml
+++ b/tolerancy-configs/master-tolerancy.yaml
@@ -1,0 +1,8 @@
+- json_path: ["metricName", "nodeCPU-Masters", "labels.mode", "*", "max(value)"]
+  tolerancy: -15
+  # Maximum percentage of allowed failures
+  max_failures: 100
+- json_path: ["metricName", "nodeMemoryUtilization-Masters", "jobName", "*", "max(value)"]
+  tolerancy: -15
+  # Maximum percentage of allowed failures
+  max_failures: 100

--- a/tolerancy-configs/pod-latency-tolerancy-rules.yaml
+++ b/tolerancy-configs/pod-latency-tolerancy-rules.yaml
@@ -1,0 +1,8 @@
+- json_path: ["metricName", "podLatencyQuantilesMeasurement", "quantileName", "ContainersReady", "avg(P99)"]
+  tolerancy: -25
+  # Maximum percentage of allowed failures
+  max_failures: 100
+- json_path: ["metricName", "podLatencyQuantilesMeasurement", "quantileName", "Ready", "avg(P99)"]
+  tolerancy: -25
+  # Maximum percentage of allowed failures
+  max_failures: 100

--- a/tolerancy-configs/worker-agg-tolerancy.yaml
+++ b/tolerancy-configs/worker-agg-tolerancy.yaml
@@ -1,0 +1,16 @@
+- json_path: ["metricName", "nodeCPU-AggregatedWorkers", "labels.mode", "*", "avg(value)"]
+  tolerancy: -15
+  # Maximum percentage of allowed failures
+  max_failures: 100
+- json_path: ["metricName", "nodeCPU-AggregatedWorkers", "labels.mode", "*", "max(value)"]
+  tolerancy: -15
+  # Maximum percentage of allowed failures
+  max_failures: 100
+- json_path: ["metricName", "nodeMemoryAvailable-AggregatedWorkers","jobName","*","max(value)"]
+  tolerancy: -15
+  # Maximum percentage of allowed failures
+  max_failures: 50
+- json_path: ["metricName", "nodeMemoryAvailable-AggregatedWorkers","jobName","*","avg(value)"]
+  tolerancy: -15
+  # Maximum percentage of allowed failures
+  max_failures: 50

--- a/tolerancy-configs/worker-tolerancy.yaml
+++ b/tolerancy-configs/worker-tolerancy.yaml
@@ -1,0 +1,16 @@
+- json_path: ["metricName", "nodeCPU-Workers","labels.mode","*","max(value)"]
+  tolerancy: -15
+  # Maximum percentage of allowed failures
+  max_failures: 50
+- json_path: ["metricName", "nodeCPU-Workers","labels.mode","*","avg(value)"]
+  tolerancy: -15
+  # Maximum percentage of allowed failures
+  max_failures: 50
+- json_path: ["metricName", "nodeMemoryUtilization-Workers","jobName","*","max(value)"]
+  tolerancy: -15
+  # Maximum percentage of allowed failures
+  max_failures: 50
+- json_path: ["metricName", "nodeMemoryUtilization-Workers","jobName","*","avg(value)"]
+  tolerancy: -15
+  # Maximum percentage of allowed failures
+  max_failures: 50


### PR DESCRIPTION
### Description
To be able to compare among runs we need more common data metrics/points to compare against. The config files needed to have buckets that will be consistent among the tests we will compare amongst (pod/container names change every run) 

These files help be able to compare between runs of the same job type and give a proper output. Need to further work on the tolerancy and max_failures of the tolerancy_configs but have data being able to be compared properly: 
See passing job here: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/paige-e2e-multibranch/job/benchmark-comparison/105/console

