### PR TITLE
Add handling for ZeroDivisionError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ MANIFEST
 
 # Per-project virtualenvs
 .venv*/
+venv*/

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ It is suggested to use a venv to install and run touchstone.
 ```shell
 python -m venv /virtual/environment
 source /virtual/environment/bin/activate
-git clone https://github.com/cloud-bulldozer/touchstone
-cd touchstone
+git clone https://github.com/cloud-bulldozer/benchmark-comparison
+cd benchmark-comparison
 python setup.py develop
 touchstone_compare -h
 usage: touchstone_compare [-h] [--version] [--database {elasticsearch}] [--identifier-key IDENTIFIER] -u UUID [UUID ...] [-a ALIASES [ALIASES ...]] [-o {json,yaml,csv}] --config CONFIG [--output-file OUTPUT_FILE]

--- a/src/touchstone/decision_maker/__init__.py
+++ b/src/touchstone/decision_maker/__init__.py
@@ -29,19 +29,23 @@ class Compare:
         # baseline value is the current value plus the tolerancy
         base_val = input_dict[self.baseline_uuid] + input_dict[self.baseline_uuid] * self.tolerancy / 100
         for u, v in input_dict.items():
+            # skip input_dict values that are part of the baseline uuid (no comparison to self)
             if u == self.baseline_uuid:
                 continue
             try:
                 metric_percent = v * 100 / input_dict[self.baseline_uuid]
-            # ZeroDivisionError means baseline value was 0, no comparison to be made here
             except ZeroDivisionError:
-                result = "Pass"
-                deviation = 0
-                pass
-            else:
+                # both values are 0
+                if (v == 0) and (input_dict[self.baseline_uuid] == 0):
+                    metric_percent = 100
+                # just baseline value is 0
+                else:
+                    metric_percent = 0
+            finally:
                 # If percentage is greater than 100, sustract 100 from it else substract it from 100
                 deviation = metric_percent - 100 if metric_percent > 100 else 100 - metric_percent
                 deviation = -deviation if v < input_dict[self.baseline_uuid] else deviation
+                print(f"deviation is {deviation}")
                 if (self.tolerancy >= 0 and v > base_val) or (self.tolerancy < 0 and v < base_val):
                     result = "Fail"
                     self.passed = False

--- a/src/touchstone/decision_maker/__init__.py
+++ b/src/touchstone/decision_maker/__init__.py
@@ -31,16 +31,23 @@ class Compare:
         for u, v in input_dict.items():
             if u == self.baseline_uuid:
                 continue
-            metric_percent = v * 100 / input_dict[self.baseline_uuid]
-            # If percentage is greater than 100, sustract 100 from it else substract it from 100
-            deviation = metric_percent - 100 if metric_percent > 100 else 100 - metric_percent
-            deviation = -deviation if v < input_dict[self.baseline_uuid] else deviation
-            if (self.tolerancy >= 0 and v > base_val) or (self.tolerancy < 0 and v < base_val):
-                result = "Fail"
-                self.passed = False
-                self.fails += 1
-            else:
+            try:
+                metric_percent = v * 100 / input_dict[self.baseline_uuid]
+            # ZeroDivisionError means baseline value was 0, no comparison to be made here
+            except ZeroDivisionError:
                 result = "Pass"
+                deviation = 0
+                pass
+            else:
+                # If percentage is greater than 100, sustract 100 from it else substract it from 100
+                deviation = metric_percent - 100 if metric_percent > 100 else 100 - metric_percent
+                deviation = -deviation if v < input_dict[self.baseline_uuid] else deviation
+                if (self.tolerancy >= 0 and v > base_val) or (self.tolerancy < 0 and v < base_val):
+                    result = "Fail"
+                    self.passed = False
+                    self.fails += 1
+                else:
+                    result = "Pass"
             if result not in compare_dict:
                 compare_dict[result] = {}
             compare_dict[result] = {


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] Optimization
- [X] Documentation Update

## Description
Currently Touchstone can't handle comparing values where the divisor is 0 due to `ZeroDivisionError` 

This change basically allows that data to be viewed as part of the comparison even though we can't calculate an actual percentage change - defaults to `Pass` and `0.00%` - example is shown below

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
```bash
(venv) [nathan@nathan-redhat benchmark-comparison (zerodiv)]$ touchstone_compare -vv --database elasticsearch -url https://$ES_USERNAME:$ES_PASSWORD@search-ocp-qe-perf-scale-test-elk-hcm7wtsqpxy7xogbu72bor4uve.us-east-1.es.amazonaws.com:443 --uuid 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff c9a81e65-64e9-4cb1-84e9-8f0792913882 --config=netobserv_touchstone_tolerancy_config.json --tolerancy-rules netobserv_touchstone_tolerancy_rules.yaml 2> /dev/null | egrep -iB 3 -A 1 "Pass|fail"
egrep: warning: egrep is obsolescent; using grep -E
+-----------------------+-----------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|      metric_name      |      metric_name      |   metric   | result | deviation | 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff | c9a81e65-64e9-4cb1-84e9-8f0792913882 |
+-----------------------+-----------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| nFlowsProcessedTotals | nFlowsProcessedTotals | max(value) |  Fail  |  -75.49%  |              27288832.0              |              6688675.0               |
+-----------------------+-----------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
+--------------------------------+--------------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|          metric_name           |          metric_name           |   metric   | result | deviation | 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff | c9a81e65-64e9-4cb1-84e9-8f0792913882 |
+--------------------------------+--------------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| nFlowsProcessedPerMinuteTotals | nFlowsProcessedPerMinuteTotals | avg(value) |  Pass  |   2.75%   |          404844.96458333335          |           415993.42578125            |
+--------------------------------+--------------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
+---------------------+---------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|     metric_name     |     metric_name     |   metric   | result | deviation | 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff | c9a81e65-64e9-4cb1-84e9-8f0792913882 |
+---------------------+---------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| nFlowsErroredTotals | nFlowsErroredTotals | max(value) |  Pass  |   0.00%   |                 0.0                  |                 0.0                  |
+---------------------+---------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
+------------------------------+------------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|         metric_name          |         metric_name          |   metric   | result | deviation | 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff | c9a81e65-64e9-4cb1-84e9-8f0792913882 |
+------------------------------+------------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| nFlowsErroredPerMinuteTotals | nFlowsErroredPerMinuteTotals | avg(value) |  Pass  |   0.00%   |                 0.0                  |                 0.0                  |
+------------------------------+------------------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
+--------------------+--------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|    metric_name     |    metric_name     |   metric   | result | deviation | 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff | c9a81e65-64e9-4cb1-84e9-8f0792913882 |
+--------------------+--------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| lokiRecordsWritten | lokiRecordsWritten | max(value) |  Pass  |  -75.49%  |              27281852.0              |              6686261.0               |
+--------------------+--------------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
+--------------+--------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| metric_name  | metric_name  |   metric   | result | deviation | 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff | c9a81e65-64e9-4cb1-84e9-8f0792913882 |
+--------------+--------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| cpuFLPTotals | cpuFLPTotals | avg(value) |  Pass  |   0.71%   |          1.6973307073116302          |          1.7093896083533764          |
+--------------+--------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|  metric_name  |  metric_name  |   metric   | result | deviation | 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff | c9a81e65-64e9-4cb1-84e9-8f0792913882 |
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| cpuEBPFTotals | cpuEBPFTotals | avg(value) |  Pass  |  -1.20%   |          1.9241856733957927          |          1.901170140132308           |
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|  metric_name  |  metric_name  |   metric   | result | deviation | 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff | c9a81e65-64e9-4cb1-84e9-8f0792913882 |
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| cpuLokiTotals | cpuLokiTotals | avg(value) |  Pass  |  -13.34%  |          0.400474754969279           |         0.34703495912253857          |
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
+----------------+----------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|  metric_name   |  metric_name   |   metric   | result | deviation | 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff | c9a81e65-64e9-4cb1-84e9-8f0792913882 |
+----------------+----------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| cpuKafkaTotals | cpuKafkaTotals | avg(value) |  Pass  |  50.36%   |         0.12678426404794058          |         0.19063538499176502          |
+----------------+----------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
+--------------+--------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| metric_name  | metric_name  |   metric   | result | deviation | 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff | c9a81e65-64e9-4cb1-84e9-8f0792913882 |
+--------------+--------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| rssFLPTotals | rssFLPTotals | avg(value) |  Pass  |  -19.46%  |             1345875968.0             |             1083939840.0             |
+--------------+--------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|  metric_name  |  metric_name  |   metric   | result | deviation | 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff | c9a81e65-64e9-4cb1-84e9-8f0792913882 |
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| rssEBPFTotals | rssEBPFTotals | avg(value) |  Pass  |  -21.83%  |          2234848324.266667           |             1746938368.0             |
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|  metric_name  |  metric_name  |   metric   | result | deviation | 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff | c9a81e65-64e9-4cb1-84e9-8f0792913882 |
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| rssLokiTotals | rssLokiTotals | avg(value) |  Pass  |  -56.21%  |            16757993472.0             |             7338251776.0             |
+---------------+---------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
+----------------+----------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
|  metric_name   |  metric_name   |   metric   | result | deviation | 0c6cdb12-ad06-4b4a-8fa2-fb2b92fdf7ff | c9a81e65-64e9-4cb1-84e9-8f0792913882 |
+----------------+----------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
| rssKafkaTotals | rssKafkaTotals | avg(value) |  Pass  |  -28.33%  |          5287129361.066667           |             3789225216.0             |
+----------------+----------------+------------+--------+-----------+--------------------------------------+--------------------------------------+
```
