### PR TITLE
use numpy < 2.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ include_package_data = True
 package_dir =
     =src
 # Add here dependencies of your project (semicolon/line-separated), e.g.
-install_requires = elasticsearch<7.14.0; elasticsearch_dsl==7.3.0; tabulate; pyyaml; pandas
+install_requires = elasticsearch<7.14.0; elasticsearch_dsl==7.3.0; tabulate; pyyaml; pandas; numpy >= 1.22.4, < 2.0.0
 # tests_require = pytest; pytest-cov
 python_requires=>=3.6,
 


### PR DESCRIPTION
## Type of change
- [X] Dependency update
- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
numpy 2.0.0 was released on June 16, 2024 and breaks elasticsearch < 7.14 used by touchstone. This PR forces to use numpy < 2.0.0

<!--- Describe your changes in detail -->
Below is the backtrace:
```
06-17 23:26:40.152  + touchstone_compare --database elasticsearch -url 'https://ocp-qe:****@search-ocp-qe-perf-scale-test-elk-hcm7wtsqpxy7xogbu72bor4uve.us-east-1.es.amazonaws.com/' -u 09f01994-35a5-42f5-a56c-d2bd7fe21be0 --config /tmp/ingress-perf-09f01994-35a5-42f5-a56c-d2bd7fe21be0/netobserv_touchstone_statistics_config.json -o csv --output-file /home/jenkins/ws/workspace/ch-pipeline_netobserv-perf-tests/e2e-benchmarking/utils/ingress-perf-09f01994-35a5-42f5-a56c-d2bd7fe21be0.csv
06-17 23:26:40.152  2024-06-18 03:26:38,918 - touchstone - ERROR - Traceback (most recent call last):
06-17 23:26:40.153    File "/tmp/tmp.dSv5aQfM7n/lib/python3.9/site-packages/touchstone/databases/__init__.py", line 19, in grab
06-17 23:26:40.153      database_module = import_module("touchstone.databases." + module_name, package="databases")
06-17 23:26:40.153    File "/usr/local/lib/python3.9/importlib/__init__.py", line 127, in import_module
06-17 23:26:40.153      return _bootstrap._gcd_import(name[level:], package, level)
06-17 23:26:40.153    File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
06-17 23:26:40.153    File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
06-17 23:26:40.153    File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
06-17 23:26:40.153    File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
06-17 23:26:40.153    File "<frozen importlib._bootstrap_external>", line 850, in exec_module
06-17 23:26:40.153    File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
06-17 23:26:40.153    File "/tmp/tmp.dSv5aQfM7n/lib/python3.9/site-packages/touchstone/databases/elasticsearch.py", line 2, in <module>
06-17 23:26:40.153      import elasticsearch
06-17 23:26:40.153    File "/tmp/tmp.dSv5aQfM7n/lib/python3.9/site-packages/elasticsearch/__init__.py", line 36, in <module>
06-17 23:26:40.153      from .client import Elasticsearch
06-17 23:26:40.153    File "/tmp/tmp.dSv5aQfM7n/lib/python3.9/site-packages/elasticsearch/client/__init__.py", line 23, in <module>
06-17 23:26:40.153      from ..transport import Transport, TransportError
06-17 23:26:40.153    File "/tmp/tmp.dSv5aQfM7n/lib/python3.9/site-packages/elasticsearch/transport.py", line 31, in <module>
06-17 23:26:40.153      from .serializer import DEFAULT_SERIALIZERS, Deserializer, JSONSerializer
06-17 23:26:40.153    File "/tmp/tmp.dSv5aQfM7n/lib/python3.9/site-packages/elasticsearch/serializer.py", line 50, in <module>
06-17 23:26:40.153      np.float_,
06-17 23:26:40.153    File "/tmp/tmp.dSv5aQfM7n/lib/python3.9/site-packages/numpy/__init__.py", line 397, in __getattr__
06-17 23:26:40.153      raise AttributeError(
06-17 23:26:40.153  AttributeError: `np.float_` was removed in the NumPy 2.0 release. Use `np.float64` instead.
```